### PR TITLE
Fix a typo in the vagrant.sh file

### DIFF
--- a/vagrant.sh
+++ b/vagrant.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 sudo add-apt-repository -y ppa:nginx/stable
 sudo apt-get update
-sudo apt-get install -y build-essential python-dev python-pip nginx nginx-extra uwsgi uwsgi-plugin-python
+sudo apt-get install -y build-essential python-dev python-pip nginx nginx-extras uwsgi uwsgi-plugin-python
 sudo pip install virtualenv
 cd /vagrant
 virtualenv .env --always-copy --no-site-packages


### PR DESCRIPTION
The vagrant file fails due to what I assume to be a typo in the nginx-extras package.
